### PR TITLE
Update SJET-AOCODAF405V3.config

### DIFF
--- a/configs/default/SJET-AOCODAF405V3.config
+++ b/configs/default/SJET-AOCODAF405V3.config
@@ -14,7 +14,7 @@
 #define USE_FLASH_W25Q128FV
 #define USE_MAX7456
 
-board_name AOCODAF405V2MPU6000
+board_name AOCODAF405V3
 manufacturer_id SJET
 
 # resources
@@ -62,6 +62,7 @@ resource GYRO_CS 1 A04
 resource USB_DETECT 1 B12
 resource PINIO 1 C05
 resource PINIO 2 A14
+resource PINIO 3 C15
 
 # timer
 timer A03 AF2
@@ -124,19 +125,19 @@ serial 4 1 115200 57600 0 115200
 
 # master
 set pinio_config = 129,129,1,1
-set pinio_box = 40,41,255,255
+set pinio_box = 40,41,42,255
 set serialrx_provider = CRSF
 set gps_provider = UBLOX
+set dshot_burst = ON
 set motor_pwm_protocol = DSHOT600
 set mag_bustype = I2C
 set mag_i2c_device = 1
 set baro_bustype = I2C
 set baro_i2c_device = 1
 set blackbox_device = SPIFLASH
-set dshot_burst = ON
 set current_meter = ADC
 set battery_meter = ADC
-set ibata_scale = 500
+set ibata_scale = 206
 set beeper_inversion = ON
 set beeper_od = OFF
 set system_hse_mhz = 8


### PR DESCRIPTION
1.Serial port 1 Use GPS
2.Serial port 2 Use a receiver
3.The features of LED_STRIP、OSD、GPS are enabled by default
4. The default GPS protocol is ublox by default
5. The receiver selects CRSF protocol by default
6. The default motor protocol is Dshot600 by default
7.Bluetooth and 9v switches are enabled by default
8.Use the User1 and User2 mode，User3 mode
9.Add User3 mode. User3 mode Controls the switchover between cam1 and cam2
10.MSP for Bluetooth enabled serial port 5 by default

